### PR TITLE
Revert "Request parameters use as associative array"

### DIFF
--- a/src/JsonRpc/Server.php
+++ b/src/JsonRpc/Server.php
@@ -245,20 +245,20 @@ class Server
 					$argName = $arg->getName();
 
 					if (array_key_exists($argName, $named)) {
-						$params[$argName] = $named[$argName];
+						$params[] = $named[$argName];
 						unset($named[$argName]);
 					} else {
 						if (!$arg->isOptional()) {
 							$res = false;
 							break;
 						} else {
-							$params[$argName] = $arg->getDefaultValue();
+							$params[] = $arg->getDefaultValue();
 						}
 					}
 
 				}
 
-				if ($extra = $named) {
+				if ($extra = array_values($named)) {
 					$params = array_merge($params, $extra);
 				}
 
@@ -279,7 +279,7 @@ class Server
 	private function getParams($params) {
 
 		if (is_object($params)) {
-			$params = (array)$params;
+			$params = array_values((array)$params);
 		} elseif (is_null($params)) {
 			$params = array();
 		}


### PR DESCRIPTION
This reverts commit da29bd64e087f5f52cc5141e56f1700f802f420c.